### PR TITLE
Improved missing assertion error

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -462,7 +462,8 @@ function buildDiff(expect, err) {
 }
 
 function handleNestedExpects(expect, e, assertion) {
-    switch (assertion.errorMode) {
+    var errorMode = e.errorMode || assertion.errorMode;
+    switch (errorMode) {
     case 'nested':
         var comparison = buildDiff(expect, e);
         var message = assertion.standardErrorMessage().nl()
@@ -634,20 +635,26 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             throw err;
         }
     } else {
-        var errorMessage;
+        var errorMessage = this.output.clone();
         var definedForIncompatibleTypes = this.types.filter(function (type) {
             return this.assertions[type.name][testDescriptionString];
         }, this);
         if (definedForIncompatibleTypes.length > 0) {
-            errorMessage =
-                'The assertion "' + testDescriptionString + '" is not defined for the type "' + matchingType.name +
-                '", but it is defined for ';
+            errorMessage.error('The assertion "').strings(testDescriptionString)
+                .error('" is not defined for the type "').strings(matchingType.name).error('",').nl()
+                .error('but it is defined for ');
             if (definedForIncompatibleTypes.length === 1) {
-                errorMessage += 'the type "' + definedForIncompatibleTypes[0].name + '"';
+                errorMessage.error('the type "').strings(definedForIncompatibleTypes[0].name).error('"');
             } else {
-                errorMessage += 'these types: ' + definedForIncompatibleTypes.map(function (incompatibleType) {
-                    return '"' + incompatibleType.name + '"';
-                }).join(', ');
+                errorMessage.error('these types: ');
+
+
+                definedForIncompatibleTypes.forEach(function (incompatibleType, index) {
+                    if (index > 0) {
+                        errorMessage.error(', ');
+                    }
+                    errorMessage.error('"').strings(incompatibleType.name).error('"');
+                });
             }
         } else {
             var assertionsWithScore = [];
@@ -669,12 +676,17 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             assertionsWithScore.sort(function (a, b) {
                 return b.score - a.score;
             });
-            errorMessage =
-                'Unknown assertion "' + testDescriptionString + '", ' +
-                'did you mean: "' + assertionsWithScore[0].assertion + '"';
+            errorMessage.error('Unknown assertion "').strings(testDescriptionString)
+                .error('", did you mean: "').strings(assertionsWithScore[0].assertion).error('"');
         }
-
-        throw truncateStack(new Error(errorMessage), this.expect);
+        var missingAssertionError = new Error();
+        missingAssertionError.output = errorMessage;
+        missingAssertionError._isUnexpected = true;
+        missingAssertionError.errorMode = 'bubble';
+        if (nestingLevel === 0) {
+            this.setErrorMessage(missingAssertionError);
+        }
+        this.fail(missingAssertionError);
     }
 };
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -655,7 +655,9 @@ describe('unexpected', function () {
         it('fails if the argument is not a function', function () {
             expect(function () {
                 expect(1, 'to throw exception');
-            }, 'to throw exception', 'The assertion "to throw exception" is not defined for the type "number", but it is defined for the type "function"');
+            }, 'to throw exception',
+                   'The assertion "to throw exception" is not defined for the type "number",\n' +
+                   'but it is defined for the type "function"');
         });
 
         it('given a function the function is called with the exception', function () {
@@ -790,7 +792,9 @@ describe('unexpected', function () {
         it('throws when the assertion fails', function () {
             expect(function () {
                 expect(null, 'not to contain', 'world');
-            }, 'to throw', 'The assertion "not to contain" is not defined for the type "null", but it is defined for these types: "string", "arrayLike"');
+            }, 'to throw',
+                   'The assertion "not to contain" is not defined for the type "null",\n' +
+                   'but it is defined for these types: "string", "arrayLike"');
 
             expect(function () {
                 expect('hello world', 'to contain', 'foo');
@@ -810,7 +814,9 @@ describe('unexpected', function () {
 
             expect(function () {
                 expect(1, 'to contain', 1);
-            }, 'to throw exception', 'The assertion "to contain" is not defined for the type "number", but it is defined for these types: "string", "arrayLike"');
+            }, 'to throw exception',
+                   'The assertion "to contain" is not defined for the type "number",\n' +
+                   'but it is defined for these types: "string", "arrayLike"');
         });
 
         it('produces a diff when the array case fails and the not flag is on', function () {
@@ -869,7 +875,9 @@ describe('unexpected', function () {
 
             expect(function () {
                 expect(null, 'to have length', 4);
-            }, 'to throw exception', 'The assertion "to have length" is not defined for the type "null", but it is defined for these types: "string", "object"');
+            }, 'to throw exception',
+                   'The assertion "to have length" is not defined for the type "null",\n' +
+                   'but it is defined for these types: "string", "object"');
 
             expect(function () {
                 expect({ length: 'foo' }, 'to have length', 4);
@@ -897,7 +905,9 @@ describe('unexpected', function () {
 
             expect(function () {
                 expect(null, 'to have property', 'b');
-            }, 'to throw exception', 'The assertion "to have property" is not defined for the type "null", but it is defined for the type "object"');
+            }, 'to throw exception',
+                   'The assertion "to have property" is not defined for the type "null",\n' +
+                   'but it is defined for the type "object"');
 
             expect(function () {
                 expect({a: 'b'}, 'to have property', 'a', 'c');
@@ -910,12 +920,16 @@ describe('unexpected', function () {
             expect(function () {
                 // property expectations ignores value if property
                 expect(null, 'not to have property', 'a', 'b');
-            }, 'to throw exception', 'The assertion "not to have property" is not defined for the type "null", but it is defined for the type "object"');
+            }, 'to throw exception',
+                   'The assertion "not to have property" is not defined for the type "null",\n' +
+                   'but it is defined for the type "object"');
 
             expect(function () {
                 // property expectations on value expects the property to be present
                 expect(null, 'not to have own property', 'a', 'b');
-            }, 'to throw exception', 'The assertion "not to have own property" is not defined for the type "null", but it is defined for the type "object"');
+            }, 'to throw exception',
+                   'The assertion "not to have own property" is not defined for the type "null",\n' +
+                   'but it is defined for the type "object"');
         });
     });
 
@@ -1068,7 +1082,9 @@ describe('unexpected', function () {
 
             expect(function () {
                 expect(null, 'to be empty');
-            }, 'to throw exception', 'The assertion "to be empty" is not defined for the type "null", but it is defined for these types: "string", "object"');
+            }, 'to throw exception',
+                   'The assertion "to be empty" is not defined for the type "null",\n' +
+                   'but it is defined for these types: "string", "object"');
         });
     });
 
@@ -1157,7 +1173,9 @@ describe('unexpected', function () {
             }, 'to throw exception', "expected 4 not to be within '0..4'");
             expect(function () {
                 expect(null, 'not to be within', 0, 4);
-            }, 'to throw exception', 'The assertion "not to be within" is not defined for the type "null", but it is defined for these types: "number", "string"');
+            }, 'to throw exception',
+                   'The assertion "not to be within" is not defined for the type "null",\n' +
+                   'but it is defined for these types: "number", "string"');
         });
     });
 
@@ -1483,6 +1501,18 @@ describe('unexpected', function () {
             }, 'to throw exception', "expected [Error: { message: 'foo' }] to satisfy /bar/");
         });
 
+        it('fails when using an unknown assertion', function () {
+            expect(function () {
+                expect({ bool: 'true' }, 'to satisfy', { bool: expect.it('to be true') });
+            }, 'to throw exception',
+                   "expected { bool: 'true' } to satisfy { bool: expect.it('to be true') }\n" +
+                   "\n" +
+                   "{\n" +
+                   "  bool: 'true' // The assertion \"to be true\" is not defined for the type \"string\",\n" +
+                   "               // but it is defined for the type \"boolean\"\n" +
+                   "}");
+        });
+
         it('fails is error does not satisfy properties of given object', function () {
             expect(function () {
                 expect(new Error('foo'), 'to satisfy', { message: 'bar' });
@@ -1723,7 +1753,9 @@ describe('unexpected', function () {
         it('only accepts arrays as the target object', function () {
             expect(function () {
                 expect(42, 'to be an array whose items satisfy', function (item) {});
-            }, 'to throw', 'The assertion "to be an array whose items satisfy" is not defined for the type "number", but it is defined for the type "arrayLike"');
+            }, 'to throw',
+                   'The assertion "to be an array whose items satisfy" is not defined for the type "number",\n' +
+                   'but it is defined for the type "arrayLike"');
         });
 
         it('supports the non-empty clause', function () {
@@ -1814,7 +1846,9 @@ describe('unexpected', function () {
         it('only accepts objects and arrays as the target', function () {
             expect(function () {
                 expect(42, 'to be a map whose values satisfy', function (value) {});
-            }, 'to throw', 'The assertion "to be a map whose values satisfy" is not defined for the type "number", but it is defined for the type "object"');
+            }, 'to throw',
+                   'The assertion "to be a map whose values satisfy" is not defined for the type "number",\n' +
+                   'but it is defined for the type "object"');
         });
 
         it('asserts that the given callback does not throw for any values in the map', function () {
@@ -1898,7 +1932,9 @@ describe('unexpected', function () {
         it('only accepts objects as the target', function () {
             expect(function () {
                 expect(42, 'to be a map whose keys satisfy', function (key) {});
-            }, 'to throw', 'The assertion "to be a map whose keys satisfy" is not defined for the type "number", but it is defined for the type "object"');
+            }, 'to throw',
+                   'The assertion "to be a map whose keys satisfy" is not defined for the type "number",\n' +
+                   'but it is defined for the type "object"');
         });
 
         it('asserts that the given callback does not throw for any keys in the map', function () {
@@ -2432,7 +2468,9 @@ describe('unexpected', function () {
                     clonedExpect(['foobarquux'], 'to foobarquux');
                     expect(function () {
                         clonedExpect('foobarquux', 'to foobarquux');
-                    }, 'to throw', 'The assertion "to foobarquux" is not defined for the type "string", but it is defined for the type "array"');
+                    }, 'to throw',
+                           'The assertion "to foobarquux" is not defined for the type "string",\n' +
+                           'but it is defined for the type "array"');
                 });
 
                 it('prefers to suggest a similarly named assertion defined for the correct type over an exact match defined for other types', function () {
@@ -2443,13 +2481,17 @@ describe('unexpected', function () {
                     });
                     expect(function () {
                         clonedExpect(['fooo'], 'to fooo');
-                    }, 'to throw', 'The assertion "to fooo" is not defined for the type "array", but it is defined for the type "string"');
+                    }, 'to throw',
+                           'The assertion "to fooo" is not defined for the type "array",\n' +
+                           'but it is defined for the type "string"');
                     clonedExpect.addAssertion('null', 'to fooo', function (expect, subject) {
                         expect(subject.message, 'to equal', 'fooo');
                     });
                     expect(function () {
                         clonedExpect(['fooo'], 'to fooo');
-                    }, 'to throw', 'The assertion "to fooo" is not defined for the type "array", but it is defined for these types: "null", "string"');
+                    }, 'to throw',
+                           'The assertion "to fooo" is not defined for the type "array",\n' +
+                           'but it is defined for these types: "null", "string"');
                 });
 
                 it('prefers to suggest a similarly named assertion for a more specific type', function () {


### PR DESCRIPTION
This pull request introduces `errorMode` overriding by setting the `errorMode` on
an error.

Adds colors to the missing assertion error.

Add a newline to the missing assertion error as it is long.

Support nesting the missing assertion errors into satisfy diffs.