### PR TITLE
Introduce a NaN type so the number assertions can refuse to work on it

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -44,7 +44,7 @@ module.exports = function (expect) {
         expect(subject, 'not to be undefined');
     });
 
-    expect.addAssertion('number', '[not] to be NaN', function (expect, subject) {
+    expect.addAssertion(['number', 'NaN'], '[not] to be NaN', function (expect, subject) {
         expect(isNaN(subject), '[not] to be truthy');
     });
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -850,6 +850,13 @@ module.exports = function (expect) {
     });
 
     expect.addType({
+        name: 'NaN',
+        identify: function (value) {
+            return typeof value === 'number' && isNaN(value);
+        }
+    });
+
+    expect.addType({
         name: 'boolean',
         identify: function (value) {
             return typeof value === 'boolean';

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1173,7 +1173,14 @@ describe('unexpected', function () {
             expect(0, 'to be finite');
             expect(Infinity, 'not to be finite');
             expect(-Infinity, 'not to be finite');
-            expect(NaN, 'not to be finite');
+        });
+
+        it('refuses to work on NaN', function () {
+            expect(function () {
+                expect(NaN, 'not to be finite');
+            }, 'to throw',
+                   'The assertion "not to be finite" is not defined for the type "NaN",\n' +
+                   'but it is defined for the type "number"');
         });
 
         it('throws when the assertion fails', function () {
@@ -1183,13 +1190,20 @@ describe('unexpected', function () {
         });
     });
 
-    describe('finite assertion', function () {
+    describe('infinite assertion', function () {
         it('asserts a infinite number', function () {
             expect(123, 'not to be infinite');
             expect(0, 'not to be infinite');
             expect(Infinity, 'to be infinite');
             expect(-Infinity, 'to be infinite');
-            expect(NaN, 'not to be infinite');
+        });
+
+        it('refuses to work on NaN', function () {
+            expect(function () {
+                expect(NaN, 'not to be infinite');
+            }, 'to throw',
+                   'The assertion "not to be infinite" is not defined for the type "NaN",\n' +
+                   'but it is defined for the type "number"');
         });
 
         it('throws when the assertion fails', function () {
@@ -1261,6 +1275,14 @@ describe('unexpected', function () {
             expect(function () {
                 expect(0, 'to be greater than', 0);
             }, 'to throw exception', "expected 0 to be greater than 0");
+        });
+
+        it('refuses to compare NaN to a number', function () {
+            expect(function () {
+                expect(NaN, 'not to be greater than', 1);
+            }, 'to throw',
+                   'The assertion "not to be greater than" is not defined for the type "NaN",\n' +
+                   'but it is defined for these types: "number", "string"');
         });
     });
 


### PR DESCRIPTION
This means that things like expect(NaN, 'not to be greater than', 0); will no longer succeed.

Fixes #106.