### PR TITLE
Add bower.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules/
 /coverage/
-/unexpected.js

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ endif
 
 .PHONY: release-%
 release-%: git-dirty-check lint ${TARGETS} test-phantomjs
+	git add unexpected.js && git commit -m "Build unexpected.js"
 	npm version $*
 	@echo $* release ready to be publised to NPM
 	@echo Remember to push tags

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "unexpected",
+  "authors": [
+    "Sune Simonsen <sune@we-knowhow.dk>"
+  ],
+  "description": "Minimalistic BDD assertion toolkit",
+  "main": "unexpected.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "assert",
+    "expect",
+    "bdd",
+    "tdd",
+    "assertion",
+    "unexpected",
+    "test"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "site-build",
+    "lib",
+    "images",
+    "vendor",
+    "Development.md",
+    "Makefile",
+    "coverage"
+  ]
+}


### PR DESCRIPTION
This is the first step towards making unexpected more accessible for bower users.

Before merging this branch a new publishing flow should be put in place which adds `unexpected.js` to version control when preparing a release.

Currently there is no easy way for consumers to get a built `unexpected.js`-file without installing unexpected npm dependencies and having a *nix environment available to run the make command. This is a huge blocker and should be remedied